### PR TITLE
Add adapter for Picasso version e (v2.71828)

### DIFF
--- a/FishBun/src/main/java/com/sangcomz/fishbun/adapter/image/impl/PicassoEAdapter.java
+++ b/FishBun/src/main/java/com/sangcomz/fishbun/adapter/image/impl/PicassoEAdapter.java
@@ -1,0 +1,32 @@
+
+package com.sangcomz.fishbun.adapter.image.impl;
+
+import android.content.Context;
+import android.net.Uri;
+import android.widget.ImageView;
+
+import com.sangcomz.fishbun.adapter.image.ImageAdapter;
+import com.squareup.picasso.Picasso;
+
+
+public class PicassoEAdapter implements ImageAdapter {
+    @Override
+    public void loadImage(Context context, ImageView target, Uri loadUrl) {
+        Picasso
+                .get()
+                .load(loadUrl)
+                .fit()
+                .centerCrop()
+                .into(target);
+    }
+
+    @Override
+    public void loadDetailImage(Context context, ImageView target, Uri loadUrl) {
+        Picasso
+                .get()
+                .load(loadUrl)
+                .fit()
+                .centerInside()
+                .into(target);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Setting up _FishBun_ requires to add this Gradle configuration:
         // Under the Android Plugin 3.0.0. 
         compile 'com.sangcomz:FishBun:0.8.6'
         
+        compile 'com.squareup.picasso:picasso:2.71828'
+        or
         compile 'com.squareup.picasso:picasso:2.5.2'
         or
         compile 'com.github.bumptech.glide:glide:4.5.0'
@@ -120,6 +122,8 @@ Setting up _FishBun_ requires to add this Gradle configuration:
         // Android plugin 3.0.0 or higher.
         implementation 'com.sangcomz:FishBun:0.8.6'
         
+        implementation 'com.squareup.picasso:picasso:2.71828'
+        or
         implementation 'com.squareup.picasso:picasso:2.5.2'
         or
         implementation 'com.github.bumptech.glide:glide:4.5.0'
@@ -140,7 +144,9 @@ Use _FishBun_ in an activity:
 
 or in a fragment:
 
-    FishBun.with(YourFragment).setImageAdapter(new PicassoAdapter()).startAlbum();
+    FishBun.with(YourFragment).setImageAdapter(new PicassoEAdapter()).startAlbum();
+    // Use PicassoEAdapter for Picasso 2.71828 or PicassoAdapter for older versions
+    // FishBun.with(YourFragment).setImageAdapter(new PicassoAdapter()).startAlbum();
 
 and implement `OnActivityResult`:
 


### PR DESCRIPTION
###### This PR:
 - Adds adapter for Picasso version e (v2.71828)

`Picasso.with(Context)` was removed and replaced with `Picasso.get()`