### PR TITLE
Improved full image selection message

### DIFF
--- a/FishBun/src/main/res/values/strings.xml
+++ b/FishBun/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="str_all_view">All view</string>
     <string name="msg_permission">permission deny</string>
     <string name="msg_no_image">There is no album.\nTake a Picture!</string>
-    <string name="msg_full_image">You can\'t no longer choose.</string>
+    <string name="msg_full_image">Selection full. Deselect an image to choose another.</string>
     <string name="msg_loading_image">Loading...</string>
     <string name="image">image</string>
 </resources>


### PR DESCRIPTION
The message when the image selection is full the previous message didn't make much sense.

This PR changes:
- FishBun/src/main/res/values/strings.xml