### PR TITLE
Use custom file provider to avoid collision with other plugins

### DIFF
--- a/FishBun/src/main/AndroidManifest.xml
+++ b/FishBun/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <application>
         <provider
-            android:name="android.support.v4.content.FileProvider"
+            android:name="com.sangcomz.fishbun.FishBunFileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/FishBun/src/main/java/com/sangcomz/fishbun/FishBunFileProvider.java
+++ b/FishBun/src/main/java/com/sangcomz/fishbun/FishBunFileProvider.java
@@ -1,0 +1,7 @@
+package com.sangcomz.fishbun;
+
+import android.support.v4.content.FileProvider;
+
+public class FishBunFileProvider extends FileProvider {
+
+}


### PR DESCRIPTION
Original issue: https://github.com/Sh1d0w/multi_image_picker/issues/141

###### This PR changes:
 - Adds custom file provider so it does not conflict with other plugins using the file provider