### PR TITLE
Leave a space after album name

### DIFF
--- a/FishBun/src/main/java/com/sangcomz/fishbun/ui/picker/PickerActivity.java
+++ b/FishBun/src/main/java/com/sangcomz/fishbun/ui/picker/PickerActivity.java
@@ -181,7 +181,7 @@ public class PickerActivity extends BaseActivity {
                         .setTitle(album.bucketName);
             else
                 getSupportActionBar()
-                        .setTitle(album.bucketName + "(" + String.valueOf(total) + "/" + fishton.maxCount + ")");
+                        .setTitle(album.bucketName + " (" + String.valueOf(total) + "/" + fishton.maxCount + ")");
         }
     }
 


### PR DESCRIPTION
There should be a space after the album name, "Album (0/30)".

###### Fixes issue #.

###### This PR changes:
 - Adds a space after the album name, "Album (0/30)".