### PR TITLE
[FIXED] Issue where `PickerActivity` intent result is empty Uri list

### DIFF
--- a/FishBun/src/main/java/com/sangcomz/fishbun/ui/picker/PickerActivity.kt
+++ b/FishBun/src/main/java/com/sangcomz/fishbun/ui/picker/PickerActivity.kt
@@ -385,8 +385,8 @@ class PickerActivity : BaseActivity(),
      */
     override fun finishActivityWithResult(selectedImages: List<Uri>) {
         val i = Intent()
-        setResult(Activity.RESULT_OK, i)
         i.putParcelableArrayListExtra(FishBun.INTENT_PATH, ArrayList(selectedImages))
+        setResult(Activity.RESULT_OK, i)
         finish()
     }
 


### PR DESCRIPTION
###### Fixes issue #.
The issue was not reported yet.

###### This PR changes:
 - PickerActivity

The `imageData.getParcelableArrayListExtra(INTENT_PATH)` provides empty list when received from `PickerActivity`.

Similar to `AlbumActivity.kt`, fix was to set the intent data before setting the result.
See https://github.com/sangcomz/FishBun/blob/master/FishBun/src/main/java/com/sangcomz/fishbun/ui/album/ui/AlbumActivity.kt#L285
