### PR TITLE
Fixed when FishBun.isStartInAllView(true) returned empty array to onActivityResult

### DIFF
--- a/FishBun/src/main/java/com/sangcomz/fishbun/ui/picker/PickerPresenter.kt
+++ b/FishBun/src/main/java/com/sangcomz/fishbun/ui/picker/PickerPresenter.kt
@@ -104,9 +104,7 @@ class PickerPresenter internal constructor(
     }
 
     override fun onDetailImageActivityResult() {
-        val pickerViewData = pickerRepository.getPickerViewData()
-
-        if (pickerRepository.isLimitReached() && pickerViewData.isAutomaticClose) {
+        if (pickerRepository.checkForFinish()) {
             finish()
         } else {
             getPickerListItem()
@@ -128,7 +126,7 @@ class PickerPresenter internal constructor(
                 pickerView.showMinimumImageMessage(pickerRepository.getMinCount())
             }
             else -> {
-                pickerView.finishActivity()
+                finish()
             }
         }
     }
@@ -142,7 +140,7 @@ class PickerPresenter internal constructor(
                 pickerRepository.selectImage(it)
             }
         }
-        pickerView.finishActivity()
+        finish()
     }
 
     override fun onSuccessTakePicture() {

--- a/FishBun/src/main/java/com/sangcomz/fishbun/ui/picker/model/PickerRepositoryImpl.kt
+++ b/FishBun/src/main/java/com/sangcomz/fishbun/ui/picker/model/PickerRepositoryImpl.kt
@@ -108,7 +108,7 @@ class PickerRepositoryImpl(
 
     override fun checkForFinish(): Boolean =
         fishBunDataSource.getIsAutomaticClose()
-                && fishBunDataSource.getSelectedImageList().size == fishBunDataSource.getMaxCount()
+                && isLimitReached()
 
     override fun isStartInAllView() = fishBunDataSource.isStartInAllView()
 

--- a/FishBunDemo/src/main/java/com/sangcomz/fishbundemo/WithActivityActivity.kt
+++ b/FishBunDemo/src/main/java/com/sangcomz/fishbundemo/WithActivityActivity.kt
@@ -143,7 +143,6 @@ class WithActivityActivity : AppCompatActivity() {
                         .setIsUseAllDoneButton(true)
                         .setMenuDoneText("Choose")
                         .setMenuAllDoneText("Choose All")
-                        .setIsUseAllDoneButton(true)
                         .setAllViewTitle("All of your photos")
                         .setActionBarTitle("FishBun Light")
                         .textOnImagesSelectionLimitReached("You can't select any more.")


### PR DESCRIPTION
Steps to reproduce:
1. In `WithActivityActivity.kt:147` add `.isStartInAllView(true)`
2. Run demo project and select `Activity in StartActivityForResult(LIGHT)`
3. Select a photo and press `CHOOSE`

Expected result: a photo being selected
Actual result: app crashes because `path` at `WithActivityActivity.kt:60` is `null`

What changed:
1. Call `finish()` instead of `pickerView.finishActivity()` which correctly supports `isStartInAllView(true)`
2. Refactored: used `pickerRepository.checkForFinish()` everywhere
3. Removed extra `.setIsUseAllDoneButton(true)` in demo project