### PR TITLE
Update PermissionCheck.kt

### DIFF
--- a/FishBun/src/main/java/com/sangcomz/fishbun/permission/PermissionCheck.kt
+++ b/FishBun/src/main/java/com/sangcomz/fishbun/permission/PermissionCheck.kt
@@ -1,5 +1,6 @@
 package com.sangcomz.fishbun.permission
 
+import android.Manifest
 import android.Manifest.permission.*
 import android.annotation.TargetApi
 import android.app.Activity
@@ -42,9 +43,12 @@ class PermissionCheck(private val context: Context) {
 
     fun checkStoragePermission(requestCode: Int): Boolean {
         return when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q -> {
+                checkStoragePermissionUnderAPI30(requestCode)
+            }
+            Build.VERSION.SDK_INT > Build.VERSION_CODES.Q &&
                     Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU -> {
-                checkStoragePermissionUnderAPI33(requestCode)
+                checkStoragePermissionUnderAPI30To32(requestCode)
             }
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> {
                 checkStoragePermissionOrHigherAPI33(requestCode)
@@ -54,9 +58,17 @@ class PermissionCheck(private val context: Context) {
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    fun checkStoragePermissionUnderAPI33(requestCode: Int): Boolean {
+    fun checkStoragePermissionUnderAPI30(requestCode: Int): Boolean {
         return checkPermission(
             arrayListOf(READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE),
+            requestCode
+        )
+    }
+
+    @TargetApi(Build.VERSION_CODES.R)
+    private fun checkStoragePermissionUnderAPI30To32(requestCode: Int): Boolean {
+        return checkPermission(
+            arrayListOf(READ_EXTERNAL_STORAGE),
             requestCode
         )
     }


### PR DESCRIPTION
Added handling for the removing the WRITE_EXTERNAL_STORAGE permission in case of API 30 to 32

###### Fixes issue #.

###### This PR changes:

How to recreate
Create an app with targetApiVersion 33. 
Use a device with API version between 30-32.
Create a picker activity instance and it will return "Permission Denied" toast everytime but all the permissions required are given.

Changes Done: Added another statement to check for only READ_EXTERNAL_STORAGE in case of api version between 30 to 32.

 - 